### PR TITLE
fix(styles): Mobile width adjust to window size

### DIFF
--- a/chapters/the-road-to-composition/pure-functions.md
+++ b/chapters/the-road-to-composition/pure-functions.md
@@ -10,8 +10,8 @@ title: Pure Functions
 In this chapter we will begin our journey by exploring functions. We will look
 at a piece of code that violates the principle of immutability and explore the
 implications, and refactor it using pure functions. If you're here to learn
-about `fp-ts` and are already familiar with the idea of pure functions, you can
-safely skip this chapter.
+about [fp-ts](https://gcanti.github.io/fp-ts/) and are already familiar with the
+idea of pure functions, you can safely skip this chapter.
 
 ### Prelude: Mondays
 

--- a/source/styles/_global.scss
+++ b/source/styles/_global.scss
@@ -15,16 +15,16 @@ body {
     align-items: flex-start;
 
     .nav {
-        flex-basis: 14.5rem;
+        width: 14.5rem;
         padding: .5rem;
+        margin-bottom: 2rem;
         border: 1px solid #1e1e1e;
     }
 
     .main {
+        width: 50rem;
+        max-width: 100vw;
         padding: 0 2rem;
-        max-width: 50rem;
-        flex-basis: 0;
-        flex-grow: 1;
     }
 }
 


### PR DESCRIPTION
Closes #1 

Before:

<img width="403" alt="Screenshot 2020-02-03 at 09 22 51" src="https://user-images.githubusercontent.com/8309423/73636685-c9888f80-4666-11ea-885e-4e725e0a6563.png">
<img width="303" alt="Screenshot 2020-02-03 at 09 22 30" src="https://user-images.githubusercontent.com/8309423/73636686-ca212600-4666-11ea-834a-ea04a2e063f7.png">

After: 

<img width="462" alt="Screenshot 2020-02-03 at 09 21 47" src="https://user-images.githubusercontent.com/8309423/73636696-d1e0ca80-4666-11ea-94fb-0895f18bd5e2.png">
<img width="290" alt="Screenshot 2020-02-03 at 09 22 02" src="https://user-images.githubusercontent.com/8309423/73636697-d1e0ca80-4666-11ea-94ba-9c561c3df8c3.png">
