### PR TITLE
feat(styles): Light mode for git code blocks

### DIFF
--- a/source/styles/_code.scss
+++ b/source/styles/_code.scss
@@ -72,8 +72,7 @@ pre[class*="language-"] {
 }
 
 .token.deleted {
-    background-color: #752809;
-    color: white;
+    color: #cb2431;
 }
 
 .token.selector,
@@ -85,8 +84,7 @@ pre[class*="language-"] {
 }
 
 .token.inserted {
-    background-color: #355d21;
-    color: white;
+    color: #28a745;
 }
 
 .token.operator,
@@ -178,6 +176,12 @@ pre[class*="language-"] {
 /*********************************************************
  * Language Specific
  */
+pre[class*="language-git"],
+code[class*="language-git"] {
+    color: #6a737d;
+    background: #fafbfc;
+}
+
 pre[class*="language-javascript"],
 code[class*="language-javascript"] {
     color: #4ec9b0;


### PR DESCRIPTION
Dark mode with background color highlights is a bit hard to read on the git diff code blocks. Used GitHub's colors since most people is familiar with that.

NOTE: This is just a suggestion, feel free to close if you like the dark mode better.

Before:

<img width="751" alt="Screenshot 2020-02-03 at 09 33 16" src="https://user-images.githubusercontent.com/8309423/73637411-83343000-4668-11ea-801a-79d6e882f04a.png">

After:

<img width="760" alt="Screenshot 2020-02-03 at 09 33 58" src="https://user-images.githubusercontent.com/8309423/73637426-8b8c6b00-4668-11ea-9978-fd53d2cb7041.png">

<img width="770" alt="Screenshot 2020-02-03 at 09 32 46" src="https://user-images.githubusercontent.com/8309423/73637430-8d562e80-4668-11ea-865a-cd24db71c2f4.png">
